### PR TITLE
Add -filelist argument to read files from a file

### DIFF
--- a/ltags
+++ b/ltags
@@ -1,11 +1,14 @@
 #!/usr/bin/env lua
 
+require "io"
+
 local usage = [[
 Lua extended tag file generator, vs 0.1
 usage: ltags [options]  <scripts>
     -nv  no variables
     -nr  no local require variables (implied by -nv)
     -v verbose
+    -filelist <file-containing-filenames>
 ]]
 
 local TAG_HEADER = [[
@@ -161,7 +164,13 @@ local function parse_args ()
         end
         i = i + 1
     end    
-    return glob(args), opts
+    local files = glob(args)
+    if opts.filelist then
+        for line in io.lines(opts.filelist) do
+            table.insert(files, line)
+        end
+    end
+    return files, opts
 end
 
 local files, opts = parse_args()

--- a/readme.md
+++ b/readme.md
@@ -24,3 +24,7 @@ Class systems that return the class table from require produce lots of noise but
 removed by -nv (it's too aggressive). If we had `local Animal = class(function(a,name) a.name = name end)`,
 then that definition would be removed by -nv but is retained with -nr and imports of that class like `local
 Animal = require("Animal")` are not tagged.
+
+The `-filelist` option takes a file full of filenames to process.
+Passing filenames in a file instead of on the command-line may be preferable if you cannot use globs or have
+other scripts that determine which files to parse.


### PR DESCRIPTION
If you have many lua files, then you may not be able to pass them all on
the commandline. If you can't use globs either (Win32) or already have a
list of files built, then you can use the -filelist argument to pass a
file containing newline separated filenames.

You can still pass files after the -filelist argument.