### PR TITLE
Add -nr option to exclude local requires

### DIFF
--- a/ltags
+++ b/ltags
@@ -4,6 +4,7 @@ local usage = [[
 Lua extended tag file generator, vs 0.1
 usage: ltags [options]  <scripts>
     -nv  no variables
+    -nr  no local require variables (implied by -nv)
     -v verbose
 ]]
 
@@ -20,6 +21,7 @@ local entries, append = {}, table.insert
 
 local function process_file (file, opts)
     local tag_vars = not opts.nv
+    local tag_require = not opts.nr
     local skip, end_block, mod_name
     for line in io.lines(file) do
         -- skipping commentary --
@@ -52,11 +54,13 @@ local function process_file (file, opts)
                 end
                 -- look for file-scope locals (we assume that everyone uses indentation)
                 local_var = line:match '^local%s+(.+)'
-                if local_var  and tag_vars then
-                    -- not interested in actual values (for now)
-                    local_var = local_var:gsub('%s*=.+','')
-                    for w in local_var:gmatch('[%w_]+') do
-                        append(entries, {file=file, line=line, is_var=true, file_scope=true, name=w})
+                if local_var and tag_vars then
+                    if tag_require or local_var:find('=%s*require%W') == nil then
+                        -- not interested in actual values (for now)
+                        local_var = local_var:gsub('%s*=.+','')
+                        for w in local_var:gmatch('[%w_]+') do
+                            append(entries, {file=file, line=line, is_var=true, file_scope=true, name=w})
+                        end
                     end
                 end
             else -- Houston, we have a Function

--- a/readme.md
+++ b/readme.md
@@ -18,3 +18,9 @@ The common practice of declaring imported functions as locals up front can compl
 the simple business of going to the original definition.  So if we had `local imap = tablex.imap` up
 top then there would be two items with name 'imap' visible in that module - the local alias
 and the actual function.  Not a problem if your editor is comfortable with multiple tag values.
+
+The `-nr` option switches off module-level local require tagging.
+Class systems that return the class table from require produce lots of noise but the class definition is
+removed by -nv (it's too aggressive). If we had `local Animal = class(function(a,name) a.name = name end)`,
+then that definition would be removed by -nv but is retained with -nr and imports of that class like `local
+Animal = require("Animal")` are not tagged.


### PR DESCRIPTION
Class systems that return the class table from require produce lots of
noise but the class definition is removed by -nv. Add a new option
specifically for requires: -nr.

Example:

	local Animal = class(function(a,name)
	   a.name = name
	end)

	return Animal

	local Animal = require("Animal")

We want the first Animal (the singular definition of the class), but not
the second (the repeated import of the class).


(My idbrii/ltags:develop branch has this merged with #1)